### PR TITLE
YAML file to trace configuration

### DIFF
--- a/auto/configure.py
+++ b/auto/configure.py
@@ -341,6 +341,7 @@ class ConfigGenerator:
             temp_dict[option] = self._trace_config.get('secrets', option)
         temp_dict.pop("cega_user_endpoint", None)
         temp_dict.pop("cega_user_public_key", None)
+        temp_dict.pop("cega_key_password", None)
         sections_dict['secrets'] = temp_dict
         with open(self._config_path / 'trace.yml', 'w') as outfile:
             yaml.dump(sections_dict, outfile, default_flow_style=False)

--- a/auto/configure.py
+++ b/auto/configure.py
@@ -196,8 +196,8 @@ class ConfigGenerator:
         with open(self._config_path / 'user.key', "wb") as f:
             f.write(pem)
 
-        # self._trace_config.set('secrets', 'cega_user_public_key', public_key.decode('utf-8'))
-        # self._trace_config.set('secrets', 'cega_key_password', password)
+        self._trace_config.set('secrets', 'cega_user_public_key', public_key.decode('utf-8'))
+        self._trace_config.set('secrets', 'cega_key_password', password)
 
         return public_key.decode('utf-8')
 
@@ -335,13 +335,12 @@ class ConfigGenerator:
 
     def write_trace_yml(self):
         """Create trace YAML file with parameters for deployment."""
-        # print(self._trace_config._sections['secrets'])
         sections_dict = {}
-
-        # get sections and iterate over each
         temp_dict = {}
         for option in self._trace_config.options('secrets'):
             temp_dict[option] = self._trace_config.get('secrets', option)
+        temp_dict.pop("cega_user_endpoint", None)
+        temp_dict.pop("cega_user_public_key", None)
         sections_dict['secrets'] = temp_dict
         with open(self._config_path / 'trace.yml', 'w') as outfile:
             yaml.dump(sections_dict, outfile, default_flow_style=False)

--- a/auto/configure.py
+++ b/auto/configure.py
@@ -13,6 +13,7 @@ import secrets
 import string
 import hashlib
 from base64 import b64encode
+import yaml
 
 from pgpy import PGPKey, PGPUID
 from pgpy.constants import PubKeyAlgorithm, KeyFlags, HashAlgorithm, SymmetricKeyAlgorithm, CompressionAlgorithm
@@ -46,7 +47,7 @@ class ConfigGenerator:
         self._broker_service = services['broker']
         self._config_path = config_path
         self._trace_config = configparser.RawConfigParser()
-        self._trace_config.add_section('PARAMETERS')
+        self._trace_config.add_section('secrets')
 
         if not os.path.exists(self._config_path):
             try:
@@ -195,8 +196,8 @@ class ConfigGenerator:
         with open(self._config_path / 'user.key', "wb") as f:
             f.write(pem)
 
-        self._trace_config.set('PARAMETERS', 'cega_user_public_key', public_key.decode('utf-8'))
-        self._trace_config.set('PARAMETERS', 'cega_key_password', password)
+        # self._trace_config.set('secrets', 'cega_user_public_key', public_key.decode('utf-8'))
+        # self._trace_config.set('secrets', 'cega_key_password', password)
 
         return public_key.decode('utf-8')
 
@@ -218,7 +219,7 @@ class ConfigGenerator:
             {{"source":"localega.v1","vhost":"lega","destination_type":"queue","arguments":{{}},"destination":"completed","routing_key":"files.completed"}},
             {{"source":"localega.v1","vhost":"lega","destination_type":"queue","arguments":{{}},"destination":"errors","routing_key":"files.error"}}]\r\n}}""".format(self._hash_pass(generated_secret))
         cega_config_mq = """%% -*- mode: erlang -*- \r\n%%\r\n[{rabbit,[{loopback_users, [ ] },\r\n {disk_free_limit, "1GB"}]},\r\n{rabbitmq_management, [ {load_definitions, "/etc/rabbitmq/defs.json"} ]}\r\n]."""
-        self._trace_config.set('PARAMETERS', 'cega_mq_pass', generated_secret)
+        self._trace_config.set('secrets', 'cega_mq_pass', generated_secret)
 
         with open(self._config_path / 'cega.config', "w") as cega_config:
             cega_config.write(cega_config_mq)
@@ -251,7 +252,7 @@ class ConfigGenerator:
         {{rabbitmq_management, [ {{ listener, [ {{ port, 15672 }}, {{ ssl, false }}] }},
                                  {{ load_definitions, "/etc/rabbitmq/defs.json"}} ]}}\r\n].""".format(mq_secret)
 
-        self._trace_config.set('PARAMETERS', 'mq_password', mq_secret)
+        self._trace_config.set('secrets', 'mq_password', mq_secret)
 
         with open(self._config_path / 'rabbitmq.config', "w") as config:
             config.write(mq_config)
@@ -327,10 +328,23 @@ class ConfigGenerator:
         with open(self._config_path / 'keys.ini', file_flag) as configfile:
             config.write(configfile)
 
-    def write_trace_file(self):
+    def write_trace_ini(self):
         """Create trace config file with parameters for deployment."""
         with open(self._config_path / 'trace.ini', 'w') as configfile:
             self._trace_config.write(configfile)
+
+    def write_trace_yml(self):
+        """Create trace YAML file with parameters for deployment."""
+        # print(self._trace_config._sections['secrets'])
+        sections_dict = {}
+
+        # get sections and iterate over each
+        temp_dict = {}
+        for option in self._trace_config.options('secrets'):
+            temp_dict[option] = self._trace_config.get('secrets', option)
+        sections_dict['secrets'] = temp_dict
+        with open(self._config_path / 'trace.yml', 'w') as outfile:
+            yaml.dump(sections_dict, outfile, default_flow_style=False)
 
 
 # if __name__ == '__main__':

--- a/auto/kube.py
+++ b/auto/kube.py
@@ -231,24 +231,24 @@ def create_config(_localega, config_path, ns, cega_mq, cega_api, cega_pwd, key_p
 
     cega_pass = conf.generate_cega_mq_auth(cega_pwd)
     cega_address = f"amqp://{_localega['cega']['user']}:{cega_pass}@{cega_mq}.{ns}:5672/{_localega['cega']['user']}"
-    conf._trace_config.set('PARAMETERS', 'cega_address', cega_address)
+    conf._trace_config.set('secrets', 'cega_address', cega_address)
 
     conf.create_conf_shared()
     conf.generate_user_auth(key_pass)
     postgres_password = conf._generate_secret(32)
-    conf._trace_config.set('PARAMETERS', 'cega_user_endpoint', _localega['cega']['endpoint'])
+    # conf._trace_config.set('secrets', 'cega_user_endpoint', _localega['cega']['endpoint'])
     cega_creds = conf._generate_secret(32)
-    conf._trace_config.set('PARAMETERS', 'cega_creds', cega_creds)
+    conf._trace_config.set('secrets', 'cega_creds', cega_creds)
     conf.generate_mq_config()
-    conf._trace_config.set('PARAMETERS', 'postgres_password', postgres_password)
+    conf._trace_config.set('secrets', 'postgres_password', postgres_password)
     s3_access = conf._generate_secret(16)
-    conf._trace_config.set('PARAMETERS', 's3_access', s3_access)
+    conf._trace_config.set('secrets', 's3_access', s3_access)
     s3_secret = conf._generate_secret(32)
-    conf._trace_config.set('PARAMETERS', 's3_secret', s3_secret)
+    conf._trace_config.set('secrets', 's3_secret', s3_secret)
     lega_password = conf._generate_secret(32)
-    conf._trace_config.set('PARAMETERS', 'lega_password', lega_password)
+    conf._trace_config.set('secrets', 'lega_password', lega_password)
     keys_password = conf._generate_secret(32)
-    conf._trace_config.set('PARAMETERS', 'keys_password', keys_password)
+    conf._trace_config.set('secrets', 'keys_password', keys_password)
 
     conf.add_conf_key(_localega['key']['expire'], _localega['key']['id'], comment=_localega['key']['comment'],
                       passphrase=None, armor=True, active=True)
@@ -256,6 +256,7 @@ def create_config(_localega, config_path, ns, cega_mq, cega_api, cega_pwd, key_p
                             location=_localega['ssl']['location'], org=_localega['ssl']['org'], email=_localega['email'])
 
     conf.write_trace_file()
+    conf.write_trace_yml()
     # return (cega_config_mq, cega_defs_mq, defs_mq, config_mq, cega_address, ssl_cert, ssl_key, user_pub, postgres_password,
     #         s3_access, s3_secret, lega_password, keys_password, cega_creds)
 
@@ -325,14 +326,14 @@ def kubernetes_deployment(_localega, config, ns, fake_cega):
     sec_keys = client.V1VolumeProjection(secret=client.V1SecretProjection(name="keyserver-secret",
                                                                           items=[client.V1KeyToPath(key="key1.sec", path="pgp/key.1"), client.V1KeyToPath(key="ssl.cert", path="ssl.cert"), client.V1KeyToPath(key="ssl.key", path="ssl.key")]))
     deploy_lega.create_namespace()
-    deploy_lega.config_secret('cega-creds', {'credentials': trace_config['PARAMETERS']['cega_creds']})
+    deploy_lega.config_secret('cega-creds', {'credentials': trace_config['secrets']['cega_creds']})
     # Create Secrets
-    deploy_lega.config_secret('cega-connection', {'address': trace_config['PARAMETERS']['cega_address']})
-    deploy_lega.config_secret('lega-db-secret', {'postgres_password': trace_config['PARAMETERS']['postgres_password']})
-    deploy_lega.config_secret('s3-keys', {'access': trace_config['PARAMETERS']['s3_access'],
-                                          'secret': trace_config['PARAMETERS']['s3_secret']})
-    deploy_lega.config_secret('lega-password', {'password': trace_config['PARAMETERS']['lega_password']})
-    deploy_lega.config_secret('keys-password', {'password': trace_config['PARAMETERS']['keys_password']})
+    deploy_lega.config_secret('cega-connection', {'address': trace_config['secrets']['cega_address']})
+    deploy_lega.config_secret('lega-db-secret', {'postgres_password': trace_config['secrets']['postgres_password']})
+    deploy_lega.config_secret('s3-keys', {'access': trace_config['secrets']['s3_access'],
+                                          'secret': trace_config['secrets']['s3_secret']})
+    deploy_lega.config_secret('lega-password', {'password': trace_config['secrets']['lega_password']})
+    deploy_lega.config_secret('keys-password', {'password': trace_config['secrets']['keys_password']})
 
     with open(_here / 'config/key.1.sec') as key_file:
         key1_data = key_file.read()
@@ -478,7 +479,7 @@ def deploy_fake_cega(deploy_lega):
     with open(_here / 'config/cega.json') as cega_defs:
         cega_defs_mq = cega_defs.read()
 
-    user_pub = trace_config['PARAMETERS']['cega_user_public_key']
+    user_pub = trace_config['secrets']['cega_user_public_key']
     ports_mq_management = [client.V1ServicePort(name="http", protocol="TCP", port=15672, target_port=15672)]
     ports_mq = [client.V1ServicePort(name="amqp", protocol="TCP", port=5672, target_port=5672),
                 client.V1ServicePort(name="epmd", protocol="TCP", port=4369, target_port=4369),

--- a/auto/kube.py
+++ b/auto/kube.py
@@ -236,7 +236,7 @@ def create_config(_localega, config_path, ns, cega_mq, cega_api, cega_pwd, key_p
     conf.create_conf_shared()
     conf.generate_user_auth(key_pass)
     postgres_password = conf._generate_secret(32)
-    # conf._trace_config.set('secrets', 'cega_user_endpoint', _localega['cega']['endpoint'])
+    conf._trace_config.set('secrets', 'cega_user_endpoint', _localega['cega']['endpoint'])
     cega_creds = conf._generate_secret(32)
     conf._trace_config.set('secrets', 'cega_creds', cega_creds)
     conf.generate_mq_config()
@@ -257,8 +257,6 @@ def create_config(_localega, config_path, ns, cega_mq, cega_api, cega_pwd, key_p
 
     conf.write_trace_ini()
     conf.write_trace_yml()
-    # return (cega_config_mq, cega_defs_mq, defs_mq, config_mq, cega_address, ssl_cert, ssl_key, user_pub, postgres_password,
-    #         s3_access, s3_secret, lega_password, keys_password, cega_creds)
 
 
 def kubernetes_deployment(_localega, config, ns, fake_cega):

--- a/auto/kube.py
+++ b/auto/kube.py
@@ -255,7 +255,7 @@ def create_config(_localega, config_path, ns, cega_mq, cega_api, cega_pwd, key_p
     conf.generate_ssl_certs(country=_localega['ssl']['country'], country_code=_localega['ssl']['country_code'],
                             location=_localega['ssl']['location'], org=_localega['ssl']['org'], email=_localega['email'])
 
-    conf.write_trace_file()
+    conf.write_trace_ini()
     conf.write_trace_yml()
     # return (cega_config_mq, cega_defs_mq, defs_mq, config_mq, cega_address, ssl_cert, ssl_key, user_pub, postgres_password,
     #         s3_access, s3_secret, lega_password, keys_password, cega_creds)

--- a/auto/requirements.txt
+++ b/auto/requirements.txt
@@ -5,4 +5,5 @@ click==6.7
 pika
 paramiko
 minio
+PyYAML
 git+https://github.com/NBISweden/LocalEGA-cryptor.git

--- a/test/README.md
+++ b/test/README.md
@@ -9,7 +9,7 @@ your own in the `Makefile`. Also `MAIN_REPO=~/LocalEGA` should reflect the path 
 
 The actual test:
 ```
-pip install -r requirements.txt
+pip install -r ../auto/requirements.txt
 make upload
 make submit
 ```


### PR DESCRIPTION
Generating YML file to trace configuration, as specified:
```
secrets:
  lega_password: <data>
  cega_mq_pass: <data>
  cega_address: <data>
  cega_creds: <data>
  mq_password: <data>
  postgres_password: <data>
  s3_access: <data>
  s3_secret: <data>
  keys_password: <data>
  passphrase: <data>
```
Generated file is in `config` directory under the name `trace.yml`.

@jbygdell did not figure out to what parameter should the `passphrase` key should be mapped to.