### PR TITLE
travis minikube bootstrap

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,10 @@ sudo: required
 
 # This moves Kubernetes specific config files.
 # Inspured by https://github.com/LiliC/travis-minikube - Provided under Apache License
+
+# We need the systemd for the kubeadm and it's default from 16.04+
+dist: xenial
+# This moves Kubernetes specific config files.
 env:
 - CHANGE_MINIKUBE_NONE_USER=true
 
@@ -16,7 +20,7 @@ before_script:
 # Download minikube.
 - curl -Lo minikube https://storage.googleapis.com/minikube/releases/latest/minikube-linux-amd64 && chmod +x minikube && sudo mv minikube /usr/local/bin/
 - sudo minikube config set WantReportErrorPrompt false
-- sudo minikube start --vm-driver=none --bootstrapper=localkube --kubernetes-version=v1.10.0
+- sudo minikube start --vm-driver=none --bootstrapper=kubeadm --kubernetes-version=v1.10.0
 # Fix the kubectl context, as it's often stale.
 - minikube update-context
 # Wait for Kubernetes to be up and ready.


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [x] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
Fixes a bug that prevented minikube to load in Travis and for that, ubuntu version needed to be changed and the bootstrap.
Following changes made at: https://github.com/LiliC/travis-minikube/blob/kubeadm/xenial/.travis.yml
More info about bootstrapper: https://github.com/kubernetes/minikube/blob/master/docs/configuring_kubernetes.md#kubeadm-bootstrapper

### Changes made
`.travis.yml` file now contains additional informatio  about the `dist:xenial` and `--bootstrapper=kubeadm` instead of `localkube`