### PR TITLE
Generate JWT token with associated key pair

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ _localega = {
               "expire": "30/DEC/30 08:00:00",
               "id": "key.1"},
       "ssl": {"country": "Finland", "country_code": "FI", "location": "Espoo", "org": "CSC"},
+      "keys_password": "password"
   }
 ```
 
@@ -58,7 +59,9 @@ config
 ├── rabbitmq.config
 ├── ssl.cert
 ├── ssl.key
+├── token.key
 ├── trace.yml
+├── token.pub
 ├── user.key
 └── user.pub
 
@@ -76,4 +79,5 @@ secrets:
   s3_access:
   s3_secret:
   shared_pgp_password:
+  token:
 ```

--- a/lega_init/configure.py
+++ b/lega_init/configure.py
@@ -187,7 +187,7 @@ class ConfigGenerator:
             "parameters":[], "global_parameters":[{{"name":"cluster_name", "value":"rabbit@localhost"}}],\r\n     "policies":[],
             "queues":[{{"name":"v1.files.inbox", "vhost":"lega", "durable":true, "auto_delete":false, "arguments":{{}}}},
             {{"name":"v1.files.stableIDs", "vhost":"lega", "durable":true, "auto_delete":false, "arguments":{{}}}},
-            {{"name":"v1.files.",           "vhost":"lega", "durable":true, "auto_delete":false, "arguments":{{}}}},
+            {{"name":"v1.files",           "vhost":"lega", "durable":true, "auto_delete":false, "arguments":{{}}}},
             {{"name":"v1.files.completed",       "vhost":"lega", "durable":true, "auto_delete":false, "arguments":{{}}}},
             {{"name":"v1.files.errors",          "vhost":"lega", "durable":true, "auto_delete":false, "arguments":{{}}}}],
             "exchanges":[{{"name":"localega.v1", "vhost":"lega", "type":"topic", "durable":true, "auto_delete":false, "internal":false, "arguments":{{}}}}],

--- a/lega_init/deploy.py
+++ b/lega_init/deploy.py
@@ -21,8 +21,9 @@ def create_config(_localega, config_path, cega):
     conf = ConfigGenerator(config_dir, _localega['key']['name'], _localega['email'])
     if cega:
         conf.generate_cega_mq_auth()
-        conf.generate_user_auth('password')
+        conf.generate_user_auth(_localega['keys_password'])
         conf._trace_secrets.update(cega_creds=conf._generate_secret(32))
+    conf.generate_token(_localega['keys_password'])
     postgres_password = conf._generate_secret(32)
     conf.generate_mq_config()
     conf._trace_secrets.update(postgres_password=postgres_password)
@@ -56,6 +57,7 @@ def main(config_path, cega):
                 'expire': '30/DEC/30 08:00:00',
                 'id': 'key.1'},
         'ssl': {'country': 'Finland', 'country_code': 'FI', 'location': 'Espoo', 'org': 'CSC'},
+        'keys_password': 'password'
     }
 
     create_config(_localega, config_path, cega)

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ PGPy==0.4.3
 click==6.7
 PyYAML
 tox
+PyJWT

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,8 @@ setup(
         'click>=6.7',
         'PGPy==0.4.3',
         'PyYAML',
-        'cryptography'
+        'cryptography',
+        'PyJWT>=1.7.1'
     ],
     entry_points={
         'console_scripts': [


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Functional change
- [x] New feature
- [x] Documentation change


### Pull request long description:
This generates a JWT Token as well as the associated key pair and add the token to `trace.yml` and the `token.key` and `token.pub` to the `config` directory.

### Changes made:
1. Added `generate_token` function
2. moved `keys_password` to config
3. updated documentation
4. Updated dependencies

### Related issues:
Fixes #14

### Additional information:
~**Not yet tested with ega-data-api DataEdge.**~

### Documentation change:
Update information on files generated.