### PR TITLE
Updated to comply with EGA images

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,13 +50,11 @@ Generated `config` directory when also using `--cega` option:
 config
 ├── cega.config
 ├── cega.json
-├── defs.json
 ├── dummy.key
 ├── dummy.pub
 ├── dummy.yml
 ├── key.1.pub
 ├── key.1.sec
-├── rabbitmq.config
 ├── ssl.cert
 ├── ssl.key
 ├── token.key
@@ -70,14 +68,19 @@ config
 Parameters generated in `config/trace.yml` when also using `--cega` file:
 ```yaml
 config:
-  cega_username: lega
+  broker_username: guest
+  cega_users_user: lega
+  cega_mq_user: lega
 secrets:
-  cega_creds:
+  cega_users_pass:
+  cega_mq_pass:
   mq_password:
+  mq_password_hash:
   pgp_passphrase:
-  postgres_password:
-  s3_access:
-  s3_secret:
+  pg_in_password:
+  pg_out_password:
+  s3_access_key:
+  s3_secret_key:
   shared_pgp_password:
   token:
 ```

--- a/lega_init/deploy.py
+++ b/lega_init/deploy.py
@@ -19,14 +19,16 @@ def create_config(_localega, config_path, cega):
 
     # Generate Configuration
     conf = ConfigGenerator(config_dir, _localega['key']['name'], _localega['email'])
+    conf.generate_mq_config()
     if cega:
         conf.generate_cega_mq_auth()
         conf.generate_user_auth(_localega['keys_password'])
-        conf._trace_secrets.update(cega_creds=conf._generate_secret(32))
+        conf._trace_secrets.update(cega_users_pass=conf._generate_secret(32))
     conf.generate_token(_localega['keys_password'])
-    postgres_password = conf._generate_secret(32)
-    conf.generate_mq_config()
-    conf._trace_secrets.update(postgres_password=postgres_password)
+    pg_in_password = conf._generate_secret(32)
+    pg_out_password = conf._generate_secret(32)
+    conf._trace_secrets.update(pg_in_password=pg_in_password)
+    conf._trace_secrets.update(pg_out_password=pg_out_password)
     s3_access_key = conf._generate_secret(16)
     conf._trace_secrets.update(s3_access_key=s3_access_key)
     s3_secret_key = conf._generate_secret(32)


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [X] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [X] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
Updates init script to be up to date with ` v0.0.1` of the EGA-archive Docker images. 
### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
* Separate db_user/password for in and out.
* Separate users/passwords for CEGA MQ and Users services.
* Added MQ password hash to trace file.
* Removed MQ config files.
### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num>" to notify Github that this PR fixes an issue. -->

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->

### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

### Mentions:
<!-- Mention users that you want to review your pull request with @<user-name>. Leave empty if not sure. -->
