### PR TITLE
Generate Certificates based on CSR

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,17 +11,20 @@ legainit
 
 Note: If `pip install .` did not install the `legainit` command try running `sudo python setup.py install`.
 
-In the `deploy.py` parameters can be configured:
+In parameters can be configured using the `--deploy-config` options:
 ```json
 _localega = {
-      "email": "test@csc.fi",
-      "key": {"name": "Test PGP",
-              "comment": "Some comment",
-              "expire": "30/DEC/30 08:00:00",
-              "id": "key.1"},
-      "ssl": {"country": "Finland", "country_code": "FI", "location": "Espoo", "org": "CSC"},
-      "keys_password": "password"
-  }
+            "email": "test@csc.fi",
+            "key": {"name": "Test PGP",
+                    "comment": "some comment",
+                    "expire": "30/DEC/30 08:00:00",
+                    "id": "key.1"},
+            "cert": {"country": "Finland", "country_code": "FI",
+                     "location": "Espoo", "org": "CSC",
+                     "common_name": "NeICLocalEGA",
+                     "org_unit": "EGA SysDev"},
+            "keys_password": "password"
+            }
 ```
 
 Using the deploy script:
@@ -54,16 +57,36 @@ Generated `config` directory when also using `--cega` option:
 config
 ├── cega.config
 ├── cega.json
+├── cega-mq.ca.crt
+├── cega-users.ca.crt
+├── csr
+│   ├── ...
+│   └── ...
+├── dataedge.ca.crt
+├── db.ca.crt
 ├── dummy.key
 ├── dummy.pub
 ├── dummy.yml
+├── filedatabase.ca.crt
+├── finalize.ca.crt
+├── htsget.ca.crt
+├── inbox.ca.crt
+├── ingest.ca.crt
 ├── key.1.pub
 ├── key.1.sec
+├── keys.ca.crt
+├── mq.ca.crt
+├── res.ca.crt
+├── root.ca.crt
+├── root.ca.key
+├── s3.ca.crt
 ├── ssl.cert
 ├── ssl.key
 ├── token.key
+├── token.pub
 ├── trace.yml
-└── token.pub
+└── verify.ca.crt
+
 ```
 
 Parameters generated in `config/trace.yml` when also using `--cega` file:

--- a/README.md
+++ b/README.md
@@ -126,3 +126,8 @@ secrets:
   shared_pgp_password:
   token:
 ```
+
+
+### License
+
+`LocalEGA-deploy-init` and all it sources are released under Apache License 2.0.

--- a/README.md
+++ b/README.md
@@ -78,8 +78,8 @@ config
 │   ├── ingest.ca.key
 │   ├── keys.ca.crt
 │   ├── keys.ca.key
-│   ├── mq.ca.crt
-│   ├── mq.ca.key
+│   ├── mq-server.ca.crt
+│   ├── mq-server.ca.key
 │   ├── res.ca.crt
 │   ├── res.ca.key
 │   ├── root.ca.crt
@@ -110,6 +110,9 @@ config:
   cega_vhost: "lega"
   cega_port: 5672
   cega_mq_ssl: 0
+  tls_cert_ending: .ca.crt
+  tls_key_ending: .ca.key
+  tls_ca_root_file: root.ca.crt
 secrets:
   cega_users_pass:
   cega_mq_pass:

--- a/README.md
+++ b/README.md
@@ -26,17 +26,21 @@ _localega = {
 
 Using the deploy script:
 ```
-╰─$ legainit --help
+➜ legainit --help
 Usage: legainit [OPTIONS]
 
   Init script generating LocalEGA configuration parameters such as passwords
   and keys.
 
 Options:
-  --config-path TEXT  Specify path for the configuration directory, default is
-                      `config` folder.
-  --cega              Generate mock configuration for CEGA.
-  --help              Show this message and exit.
+  --config-path TEXT    Specify path for the configuration directory, default
+                        is `config` folder.
+  --cega                Generate mock configuration for CEGA.
+  --deploy-config TEXT  JSON key value pair containing country specific
+                        configuration.
+  --jwt-payload TEXT    JSON with JWT token payload
+  --help                Show this message and exit.
+
 ```
 
 #### Generating Configuration

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
-[![Build Status](https://travis-ci.org/NBISweden/LocalEGA-deploy-init.svg?branch=master)](https://travis-ci.org/NBISweden/LocalEGA-deploy-init)
+[![Build Status](https://travis-ci.org/neicnordic/LocalEGA-deploy-init.svg?branch=master)](https://travis-ci.org/neicnordic/LocalEGA-deploy-init)
 
 ## LocalEGA Deployment Configuration Init
 
 **NOTE: Requires Python >3.6.**
 ```
-git clone https://github.com/NBISweden/LocalEGA-deploy-init.git
+git clone https://github.com/neicnordic/LocalEGA-deploy-init.git
 pip install .
 legainit
 ```
@@ -59,18 +59,18 @@ config
 ├── ssl.key
 ├── token.key
 ├── trace.yml
-├── token.pub
-├── user.key
-└── user.pub
-
+└── token.pub
 ```
 
 Parameters generated in `config/trace.yml` when also using `--cega` file:
 ```yaml
 config:
-  broker_username: guest
-  cega_users_user: lega
-  cega_mq_user: lega
+  broker_username: "guest"
+  cega_users_user: "lega"
+  cega_mq_user: "lega"
+  cega_vhost: "lega"
+  cega_port: 5672
+  cega_mq_ssl: 0
 secrets:
   cega_users_pass:
   cega_mq_pass:

--- a/README.md
+++ b/README.md
@@ -57,35 +57,47 @@ Generated `config` directory when also using `--cega` option:
 config
 ├── cega.config
 ├── cega.json
-├── cega-mq.ca.crt
-├── cega-users.ca.crt
-├── csr
-│   ├── ...
-│   └── ...
-├── dataedge.ca.crt
-├── db.ca.crt
+├── certs
+│   ├── cega-mq.ca.crt
+│   ├── cega-mq.ca.key
+│   ├── cega-users.ca.crt
+│   ├── cega-users.ca.key
+│   ├── dataedge.ca.crt
+│   ├── dataedge.ca.key
+│   ├── db.ca.crt
+│   ├── db.ca.key
+│   ├── filedatabase.ca.crt
+│   ├── filedatabase.ca.key
+│   ├── finalize.ca.crt
+│   ├── finalize.ca.key
+│   ├── htsget.ca.crt
+│   ├── htsget.ca.key
+│   ├── inbox.ca.crt
+│   ├── inbox.ca.key
+│   ├── ingest.ca.crt
+│   ├── ingest.ca.key
+│   ├── keys.ca.crt
+│   ├── keys.ca.key
+│   ├── mq.ca.crt
+│   ├── mq.ca.key
+│   ├── res.ca.crt
+│   ├── res.ca.key
+│   ├── root.ca.crt
+│   ├── root.ca.key
+│   ├── s3.ca.crt
+│   ├── s3.ca.key
+│   ├── ssl.cert
+│   ├── ssl.key
+│   ├── verify.ca.crt
+│   └── verify.ca.key
 ├── dummy.key
 ├── dummy.pub
 ├── dummy.yml
-├── filedatabase.ca.crt
-├── finalize.ca.crt
-├── htsget.ca.crt
-├── inbox.ca.crt
-├── ingest.ca.crt
 ├── key.1.pub
 ├── key.1.sec
-├── keys.ca.crt
-├── mq.ca.crt
-├── res.ca.crt
-├── root.ca.crt
-├── root.ca.key
-├── s3.ca.crt
-├── ssl.cert
-├── ssl.key
 ├── token.key
 ├── token.pub
-├── trace.yml
-└── verify.ca.crt
+└── trace.yml
 
 ```
 

--- a/lega_init/configure.py
+++ b/lega_init/configure.py
@@ -1,29 +1,10 @@
-from cryptography.hazmat.primitives.asymmetric import rsa
-from cryptography.hazmat.primitives import serialization
-from cryptography.hazmat.backends import default_backend
-from cryptography import x509
-from cryptography.x509.oid import NameOID
-from cryptography.hazmat.primitives import hashes
-import datetime
 import os
-import errno
 import logging
-import secrets
-import string
 import hashlib
 from base64 import b64encode
 import ruamel.yaml
 from ruamel.yaml.scalarstring import DoubleQuotedScalarString as dq
 import jwt
-
-from pgpy import PGPKey, PGPUID
-from pgpy.constants import PubKeyAlgorithm, KeyFlags, HashAlgorithm, SymmetricKeyAlgorithm, CompressionAlgorithm
-
-from cryptography.hazmat.primitives import padding
-from cryptography.hazmat.primitives.ciphers import (
-    Cipher,
-    algorithms,
-    modes)
 
 yaml = ruamel.yaml.YAML()
 yaml.default_flow_style = False
@@ -40,115 +21,15 @@ class ConfigGenerator:
     For when one needs to do create configuration files.
     """
 
-    def __init__(self, config_path, name, email):
+    def __init__(self, config_path, token_keys, auth_keys, pgp_pair):
         """Set things up."""
-        self.name = name
-        self.email = email
+        self.token_keys = token_keys
+        self.auth_keys = auth_keys
+        self.pgp_pair = pgp_pair
         self._config_path = config_path
         self._trace_config = dict()
         self._trace_config.update(secrets={})
         self._trace_secrets = self._trace_config["secrets"]
-
-        if not os.path.exists(self._config_path):
-            try:
-                os.makedirs(self._config_path)
-            except OSError as exc:  # Guard against race condition
-                if exc.errno != errno.EEXIST:
-                    raise
-
-    # Based on
-    # https://www.pythonsheets.com/notes/python-crypto.html#aes-cbc-mode-encrypt-via-password-using-cryptography
-    # Provided under MIT license: https://github.com/crazyguitar/pysheeet/blob/master/LICENSE
-
-    def _EVP_ByteToKey(self, pwd, md, salt, key_len, iv_len):
-        """Derive key and IV.
-
-        Based on https://www.openssl.org/docs/man1.0.2/crypto/EVP_BytesToKey.html
-        """
-        buf = md(pwd + salt).digest()
-        d = buf
-        while len(buf) < (iv_len + key_len):
-            d = md(d + pwd + salt).digest()
-            buf += d
-        return buf[:key_len], buf[key_len:key_len + iv_len]
-
-    def aes_encrypt(self, pwd, ptext, md):
-        """Encrypt AES."""
-        key_len, iv_len = 32, 16
-
-        # generate salt
-        salt = os.urandom(8)
-
-        # generate key, iv from password
-        key, iv = self._EVP_ByteToKey(pwd, md, salt, key_len, iv_len)
-
-        # pad plaintext
-        pad = padding.PKCS7(128).padder()
-        ptext = pad.update(ptext) + pad.finalize()
-
-        # create an encryptor
-        cipher = Cipher(algorithms.AES(key), modes.CBC(iv), backend=default_backend())
-        encryptor = cipher.encryptor()
-
-        # encrypt plain text
-        ctext = encryptor.update(ptext) + encryptor.finalize()
-        ctext = b'Salted__' + salt + ctext
-
-        # encode base64
-        return ctext
-
-    def _generate_pgp_pair(self, comment, passphrase, armor):
-        """Generate PGP key pair to be used by keyserver."""
-        # We need to specify all of our preferences because PGPy doesn't have any built-in key preference defaults at this time.
-        # This example is similar to GnuPG 2.1.x defaults, with no expiration or preferred keyserver
-        key = PGPKey.new(PubKeyAlgorithm.RSAEncryptOrSign, 4096)
-        uid = PGPUID.new(self.name, email=self.email, comment=comment)
-        key.add_uid(uid,
-                    usage={KeyFlags.Sign, KeyFlags.EncryptCommunications, KeyFlags.EncryptStorage},
-                    hashes=[HashAlgorithm.SHA256, HashAlgorithm.SHA384, HashAlgorithm.SHA512, HashAlgorithm.SHA224],
-                    ciphers=[SymmetricKeyAlgorithm.AES256, SymmetricKeyAlgorithm.AES192, SymmetricKeyAlgorithm.AES128],
-                    compression=[CompressionAlgorithm.ZLIB, CompressionAlgorithm.BZ2, CompressionAlgorithm.ZIP, CompressionAlgorithm.Uncompressed])
-
-        # Protecting the key
-        key.protect(passphrase, SymmetricKeyAlgorithm.AES256, HashAlgorithm.SHA256)
-        pub_data = str(key.pubkey) if armor else bytes(key.pubkey)  # armored or not
-        sec_data = str(key) if armor else bytes(key)  # armored or not
-
-        return (pub_data, sec_data)
-
-    def generate_ssl_certs(self, country, country_code, location, org, email, org_unit="SysDevs", common_name="LocalEGA"):
-        """Generate SSL self signed certificate."""
-        # Following https://cryptography.io/en/latest/x509/tutorial/?highlight=certificate
-        key = rsa.generate_private_key(public_exponent=65537, key_size=2048, backend=default_backend())
-        priv_key = key.private_bytes(encoding=serialization.Encoding.PEM,
-                                     format=serialization.PrivateFormat.TraditionalOpenSSL,
-                                     encryption_algorithm=serialization.NoEncryption(),)
-
-        subject = issuer = x509.Name([x509.NameAttribute(NameOID.COUNTRY_NAME, country_code),
-                                      x509.NameAttribute(NameOID.STATE_OR_PROVINCE_NAME, country),
-                                      x509.NameAttribute(NameOID.LOCALITY_NAME, location),
-                                      x509.NameAttribute(NameOID.ORGANIZATION_NAME, org),
-                                      x509.NameAttribute(NameOID.ORGANIZATIONAL_UNIT_NAME, org_unit),
-                                      x509.NameAttribute(NameOID.COMMON_NAME, common_name),
-                                      x509.NameAttribute(NameOID.EMAIL_ADDRESS, email), ])
-
-        cert = x509.CertificateBuilder().subject_name(
-            subject).issuer_name(
-            issuer).public_key(
-            key.public_key()).serial_number(
-            x509.random_serial_number()).not_valid_before(
-            datetime.datetime.utcnow()).not_valid_after(
-            datetime.datetime.utcnow() + datetime.timedelta(days=1000)).add_extension(
-            x509.SubjectAlternativeName([x509.DNSName(u"localhost")]), critical=False,).sign(
-            key, hashes.SHA256(), default_backend())
-
-        with open(self._config_path / 'ssl.cert', "w") as ssl_cert:
-            ssl_cert.write(cert.public_bytes(serialization.Encoding.PEM).decode('utf-8'))
-
-        with open(self._config_path / 'ssl.key', "w") as ssl_key:
-            ssl_key.write(priv_key.decode('utf-8'))
-
-        # return (cert.public_bytes(serialization.Encoding.PEM).decode('utf-8'), priv_key.decode('utf-8'))
 
     def _hash_pass(self, password):
         """Hashing password according to RabbitMQ specs."""
@@ -170,21 +51,8 @@ class ConfigGenerator:
 
         return pass_hash
 
-    def _generate_secret(self, value):
-        """Generate secret of specifig value.
-
-        .. note: If the value is of type integer it will generate a random of that value,
-        else it will take that value.
-        """
-        if isinstance(value, int):
-            secret = ''.join(secrets.choice(string.ascii_letters + string.digits) for i in range(value))
-            return secret
-        else:
-            return value
-
-    def generate_cega_mq_auth(self):
+    def generate_cega_mq_auth(self, generated_secret):
         """Generate CEGA MQ auth."""
-        generated_secret = self._generate_secret(32)
         cega_defs_mq = """{{"rabbit_version":"3.6",\r\n     "users":[{{"name":"lega",
             "password_hash":"{0}","hashing_algorithm":"rabbit_password_hashing_sha256","tags":"administrator"}}],   "vhosts":[{{"name":"lega"}}],
             "permissions":[{{"user":"lega", "vhost":"lega", "configure":".*", "write":".*", "read":".*"}}],\r\n
@@ -212,53 +80,37 @@ class ConfigGenerator:
         self._trace_config["config"].update(cega_port=5672)
         self._trace_config["config"].update(cega_mq_ssl=0)
 
-        with open(self._config_path / 'cega.config', "w") as cega_config:
+        with open(self._config_path + '/cega.config', "w") as cega_config:
             cega_config.write(cega_config_mq)
 
-        with open(self._config_path / 'cega.json', "w") as cega_defs:
+        with open(self._config_path + '/cega.json', "w") as cega_defs:
             cega_defs.write(cega_defs_mq)
 
         return generated_secret
 
-    def generate_token(self, password):
+    def generate_token(self, token_payload):
         """Generate RSA Key pair to be used to sign token and the JWT Token itself."""
-        private_key = rsa.generate_private_key(public_exponent=65537, key_size=4096, backend=default_backend())
-        public_key = private_key.public_key().public_bytes(encoding=serialization.Encoding.PEM, format=serialization.PublicFormat.SubjectPublicKeyInfo)
-        pem = private_key.private_bytes(encoding=serialization.Encoding.PEM,
-                                        format=serialization.PrivateFormat.TraditionalOpenSSL,
-                                        encryption_algorithm=serialization.BestAvailableEncryption(password.encode('utf-8')))  # yeah not really that secret
-
-        privkey = serialization.load_pem_private_key(pem, password=password.encode('utf-8'), backend=default_backend())
+        pem, privkey, public_key = self.token_keys
         # we set no `exp` and other claims as they are optional in a real scenario these should be set
         # See available claims here: https://www.iana.org/assignments/jwt/jwt.xhtml
         # the important claim is the "authorities"
-        token_payload = {"iss": "http://data.epouta.csc.fi",
-                         "authorities": ["EGAD01"]}
         encoded = jwt.encode(token_payload, privkey, algorithm='RS256')
         self._trace_secrets.update(token=dq(encoded.decode('utf-8')))
 
-        with open(self._config_path / 'token.key', "wb") as f:
+        with open(self._config_path + '/token.key', "wb") as f:
             f.write(pem)
 
-        with open(self._config_path / 'token.pub', "w") as f:
+        with open(self._config_path + '/token.pub', "w") as f:
             f.write(public_key.decode('utf-8'))
 
     def generate_user_auth(self, password):
         """Generate user auth for CEGA Users."""
-        key = rsa.generate_private_key(backend=default_backend(), public_exponent=65537, key_size=4096)
-
-        # get public key in OpenSSH format
-        public_key = key.public_key().public_bytes(serialization.Encoding.OpenSSH, serialization.PublicFormat.OpenSSH)
-
-        # get private key in PEM container format
-        pem = key.private_bytes(encoding=serialization.Encoding.PEM, format=serialization.PrivateFormat.TraditionalOpenSSL,
-                                encryption_algorithm=serialization.BestAvailableEncryption(password.encode('utf-8')))  # yeah not really that secret
-
+        pem, public_key = self.auth_keys
         # decode to printable strings
-        with open(self._config_path / 'dummy.key', "wb") as f:
+        with open(self._config_path + '/dummy.key', "wb") as f:
             f.write(pem)
 
-        with open(self._config_path / 'dummy.pub', "w") as f:
+        with open(self._config_path + '/dummy.pub', "w") as f:
             f.write(public_key.decode('utf-8'))
 
         user_trace = dict()
@@ -267,34 +119,31 @@ class ConfigGenerator:
         user_trace['gecos'] = "dummy user"
         user_trace.update(pubkey=public_key.decode('utf-8'))
         user_trace.update(password_hash=self._hash_pass(password))
-        with open(self._config_path / 'dummy.yml', 'w') as outfile:
+        with open(self._config_path + '/dummy.yml', 'w') as outfile:
             yaml.dump(user_trace, outfile)
 
-    def generate_mq_config(self):
+    def generate_mq_config(self, mq_secret):
         """Generate MQ defintions with custom password."""
-        mq_secret = self._generate_secret(32)
         self._trace_config["config"] = {"broker_username": dq("guest")}
         self._trace_secrets.update(mq_password=dq(mq_secret))
         self._trace_secrets.update(mq_password_hash=dq(self._hash_pass(mq_secret)))
 
-    def add_conf_key(self, expire, file_name, comment, passphrase, armor=True, active=False):
+    def add_conf_key(self, file_name, armor=True):
         """Create default keys for keyserver.
 
         .. note: Information for the key is provided as dictionary for ``key_data``,
         and should be in the format ``{'comment': '','passphrase': None, 'armor': True}.
         If a passphrase is not provided it will be generated.``
         """
-        comment = comment if comment else "Generated for use in LocalEGA."
-
-        pub, sec = self._generate_pgp_pair(comment, passphrase, armor)
-        with open(self._config_path / f'{file_name}.pub', 'w' if armor else 'bw') as f:
+        pub, sec = self.pgp_pair
+        with open(self._config_path + f'/{file_name}.pub', 'w' if armor else 'bw') as f:
             f.write(pub)
-        with open(self._config_path / f'{file_name}.sec', 'w' if armor else 'bw') as f:
+        with open(self._config_path + f'/{file_name}.sec', 'w' if armor else 'bw') as f:
             f.write(sec)
 
     def write_trace_yml(self):
         """Create trace YAML file with parameters for deployment."""
         self._trace_secrets.pop("cega_user_public_key", None)
         self._trace_secrets.pop("cega_key_password", None)
-        with open(self._config_path / 'trace.yml', 'w') as outfile:
+        with open(self._config_path + '/trace.yml', 'w') as outfile:
             yaml.dump(self._trace_config, outfile)

--- a/lega_init/configure.py
+++ b/lega_init/configure.py
@@ -145,5 +145,8 @@ class ConfigGenerator:
         """Create trace YAML file with parameters for deployment."""
         self._trace_secrets.pop("cega_user_public_key", None)
         self._trace_secrets.pop("cega_key_password", None)
+        self._trace_config["config"].update(tls_cert_ending=".ca.crt")
+        self._trace_config["config"].update(tls_key_ending=".ca.key")
+        self._trace_config["config"].update(tls_ca_root_file="root.ca.crt")
         with open(self._config_path + '/trace.yml', 'w') as outfile:
             yaml.dump(self._trace_config, outfile)

--- a/lega_init/deploy.py
+++ b/lega_init/deploy.py
@@ -4,6 +4,7 @@ import sys
 import os
 import errno
 import json
+import shutil
 from .configure import ConfigGenerator
 from .key_generation import SecurityConfigGenerator
 from pathlib import Path
@@ -21,8 +22,12 @@ def create_config(_localega, _services, _cega_services, config_path, cega, token
     Path(config_path).mkdir(parents=True, exist_ok=True)
     _here = Path(config_path)
     config_dir = _here
+    # Temporary directory to store the CSR
+    # will get deleted at the end
     if not os.path.exists(os.path.join(config_dir, 'csr')):
         os.makedirs(os.path.join(config_dir, 'csr'))
+    if not os.path.exists(os.path.join(config_dir, 'certs')):
+        os.makedirs(os.path.join(config_dir, 'certs'))
     if not os.path.exists(config_dir):
         try:
             os.makedirs(config_dir)
@@ -90,6 +95,7 @@ def create_config(_localega, _services, _cega_services, config_path, cega, token
     conf.add_conf_key(_localega['key']['id'], armor=True)
 
     conf.write_trace_yml()
+    shutil.rmtree(os.path.join(config_dir, 'csr'))
 
 
 @click.command()

--- a/lega_init/deploy.py
+++ b/lega_init/deploy.py
@@ -3,6 +3,7 @@ import click
 import sys
 import os
 import errno
+import json
 from .configure import ConfigGenerator
 from .key_generation import SecurityConfigGenerator
 from pathlib import Path
@@ -15,7 +16,7 @@ LOG = logging.getLogger(__name__)
 LOG.setLevel(logging.INFO)
 
 
-def create_config(_localega, config_path, cega):
+def create_config(_localega, config_path, cega, token_payload):
     """Generate just plain configuration."""
     Path(config_path).mkdir(parents=True, exist_ok=True)
     _here = Path(config_path)
@@ -28,34 +29,39 @@ def create_config(_localega, config_path, cega):
             if exc.errno != errno.EEXIST:
                 raise
 
-    # Generate Configuration
-    token_payload = {"iss": "http://data.epouta.csc.fi",
-                     "authorities": ["EGAD01"]}
+    # Generate Security related passwords, keys certificates
     sec_config = SecurityConfigGenerator(config_dir, _localega['key']['name'], _localega['email'])
-    token_keys = sec_config.generate_token(_localega['keys_password'])
+
+    # generate passwords
     pgp_passphrase = sec_config._generate_secret(32)
     cega_mq_auth_secret = sec_config._generate_secret(32)
     mq_auth_secret = sec_config._generate_secret(32)
+    pg_in_password = sec_config._generate_secret(32)
+    pg_out_password = sec_config._generate_secret(32)
+    s3_access_key = sec_config._generate_secret(16)
+    s3_secret_key = sec_config._generate_secret(32)
+    shared_pgp_password = sec_config._generate_secret(32)
+
+    token_keys = sec_config.generate_token(_localega['keys_password'])
     sec_config.generate_ssl_certs(country=_localega['ssl']['country'], country_code=_localega['ssl']['country_code'],
                                   location=_localega['ssl']['location'], org=_localega['ssl']['org'], email=_localega['email'])
     pgp_pair = sec_config.generate_pgp_pair(comment=_localega['key']['comment'],
                                             passphrase=pgp_passphrase, armor=True, active=True)
     auth_keys = sec_config.generate_user_auth(_localega['keys_password'])
+
+    # Generate actual configuration configuration
     conf = ConfigGenerator(config_path, token_keys, auth_keys, pgp_pair)
     conf.generate_mq_config(mq_auth_secret)
+    # generate CentralEGA configuration
     if cega:
         conf.generate_cega_mq_auth(cega_mq_auth_secret)
         conf.generate_user_auth(_localega['keys_password'])
         conf._trace_secrets.update(cega_users_pass=dq(sec_config._generate_secret(32)))
-    pg_in_password = sec_config._generate_secret(32)
-    pg_out_password = sec_config._generate_secret(32)
+
     conf._trace_secrets.update(pg_in_password=dq(pg_in_password))
     conf._trace_secrets.update(pg_out_password=dq(pg_out_password))
-    s3_access_key = sec_config._generate_secret(16)
     conf._trace_secrets.update(s3_access_key=dq(s3_access_key))
-    s3_secret_key = sec_config._generate_secret(32)
     conf._trace_secrets.update(s3_secret_key=dq(s3_secret_key))
-    shared_pgp_password = sec_config._generate_secret(32)
     conf._trace_secrets.update(shared_pgp_password=dq(shared_pgp_password))
     conf._trace_secrets.update(pgp_passphrase=dq(pgp_passphrase))
     conf.generate_token(token_payload)
@@ -67,22 +73,35 @@ def create_config(_localega, config_path, cega):
 @click.command()
 @click.option('--config-path', help='Specify path for the configuration directory, default is `config` folder.', default='config')
 @click.option('--cega', help='Generate mock configuration for CEGA.', is_flag=True)
-def main(config_path, cega):
+@click.option('--deploy-config', help='JSON key value pair containing country specific configuration.')
+@click.option('--jwt-payload', help='JSON with JWT token payload')
+def main(config_path, cega, deploy_config, jwt_payload):
     """Init script generating LocalEGA configuration parameters such as passwords and keys."""
-    _localega = {
-        'email': 'test@csc.fi',
-        # Only using one key
-        'key': {'name': 'Test PGP',
-                'comment': None,
-                'expire': '30/DEC/30 08:00:00',
-                'id': 'key.1'},
-        'ssl': {'country': 'Finland', 'country_code': 'FI', 'location': 'Espoo', 'org': 'CSC'},
-        'keys_password': 'password'
-    }
+    if deploy_config:
+        with open(deploy_config) as localega_file:
+            _localega = json.load(localega_file)
+    else:
+        _localega = {
+            'email': 'test@csc.fi',
+            # Only using one key
+            'key': {'name': 'Test PGP',
+                    'comment': None,
+                    'expire': '30/DEC/30 08:00:00',
+                    'id': 'key.1'},
+            'ssl': {'country': 'Finland', 'country_code': 'FI', 'location': 'Espoo', 'org': 'CSC'},
+            'keys_password': 'password'
+        }
+    # Token payload can be adjusted as needed
+    if jwt_payload:
+        with open(jwt_payload) as localega_file:
+            _token_payload = json.load(localega_file)
+    else:
+        _token_payload = {"iss": "http://data.epouta.csc.fi",
+                          "authorities": ["EGAD01"]}
 
-    create_config(_localega, config_path, cega)
+    create_config(_localega, config_path, cega, _token_payload)
 
 
 if __name__ == '__main__':
     assert sys.version_info >= (3, 6), "deployment config init requires python3.6"
-    main()
+    main()  # pylint: disable=no-value-for-parameter

--- a/lega_init/deploy.py
+++ b/lega_init/deploy.py
@@ -105,7 +105,7 @@ def create_config(_localega, _services, _cega_services, config_path, cega, token
 @click.option('--jwt-payload', help='JSON with JWT token payload')
 def main(config_path, cega, deploy_config, jwt_payload):
     """Init script generating LocalEGA configuration parameters such as passwords and keys."""
-    _services = ['keys', 'dataedge', 'ingest', 'verify', 'mq',
+    _services = ['keys', 'dataedge', 'ingest', 'verify', 'mq-server',
                  'db', 'finalize', 'inbox', 'filedatabase',
                  'res', 's3', 'htsget']
     _cega_services = ['cega-users', 'cega-mq']

--- a/lega_init/key_generation.py
+++ b/lega_init/key_generation.py
@@ -194,10 +194,10 @@ class SecurityConfigGenerator:
             backend=default_backend()
         )
 
-        with open(self._config_path / 'root.ca.crt', "w") as root_cert:
+        with open(self._config_path / 'certs/root.ca.crt', "w") as root_cert:
             root_cert.write(cert.public_bytes(serialization.Encoding.PEM).decode('utf-8'))
 
-        with open(self._config_path / 'root.ca.key', "wb") as root_key:
+        with open(self._config_path / 'certs/root.ca.key', "wb") as root_key:
             root_key.write(priv_key)
 
     # not sure if this is still needed
@@ -235,10 +235,10 @@ class SecurityConfigGenerator:
             backend=default_backend()
         )
 
-        with open(self._config_path / 'ssl.cert', "w") as ssl_cert:
+        with open(self._config_path / 'certs/ega_ssl.cert', "w") as ssl_cert:
             ssl_cert.write(cert.public_bytes(serialization.Encoding.PEM).decode('utf-8'))
 
-        with open(self._config_path / 'ssl.key', "w") as ssl_key:
+        with open(self._config_path / 'certs/ega_ssl.key', "w") as ssl_key:
             ssl_key.write(priv_key.decode('utf-8'))
 
         # return (cert.public_bytes(serialization.Encoding.PEM).decode('utf-8'), priv_key.decode('utf-8'))
@@ -265,7 +265,7 @@ class SecurityConfigGenerator:
         with open(self._config_path / f"csr/{service}.csr.pem", "wb") as f:
             f.write(csr.public_bytes(serialization.Encoding.PEM))
 
-        with open(self._config_path / f"csr/{service}.ca.key", "wb") as root_key:
+        with open(self._config_path / f"certs/{service}.ca.key", "wb") as root_key:
             root_key.write(priv_key)
 
     def sign_certificate_request(self, service, password):
@@ -273,10 +273,10 @@ class SecurityConfigGenerator:
         with open(self._config_path / f"csr/{service}.csr.pem", 'rb') as f:
             csr = x509.load_pem_x509_csr(data=f.read(), backend=default_backend())
 
-        with open(self._config_path / 'root.ca.crt', "rb") as root_cert:
+        with open(self._config_path / 'certs/root.ca.crt', "rb") as root_cert:
             root_ca_cert = x509.load_pem_x509_certificate(root_cert.read(), default_backend())
 
-        with open(self._config_path / 'root.ca.key', "rb") as root_key:
+        with open(self._config_path / 'certs/root.ca.key', "rb") as root_key:
             root_ca_pkey = serialization.load_pem_private_key(root_key.read(), password=password.encode('utf-8'),
                                                               backend=default_backend())
 
@@ -310,5 +310,5 @@ class SecurityConfigGenerator:
             backend=default_backend()
         )
 
-        with open(self._config_path / f"{service}.ca.crt", 'wb') as f:
+        with open(self._config_path / f"certs/{service}.ca.crt", 'wb') as f:
             f.write(cert.public_bytes(encoding=serialization.Encoding.PEM))

--- a/lega_init/key_generation.py
+++ b/lega_init/key_generation.py
@@ -1,0 +1,169 @@
+from cryptography.hazmat.primitives.asymmetric import rsa
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.backends import default_backend
+from cryptography import x509
+from cryptography.x509.oid import NameOID
+from cryptography.hazmat.primitives import hashes
+import datetime
+import os
+import secrets
+import string
+import logging
+from pgpy import PGPKey, PGPUID
+from pgpy.constants import PubKeyAlgorithm, KeyFlags, HashAlgorithm, SymmetricKeyAlgorithm, CompressionAlgorithm
+
+from cryptography.hazmat.primitives import padding
+from cryptography.hazmat.primitives.ciphers import (
+    Cipher,
+    algorithms,
+    modes)
+
+# Logging
+FORMAT = '[%(asctime)s][%(name)s][%(process)d %(processName)s][%(levelname)-8s] (L:%(lineno)s) %(funcName)s: %(message)s'
+logging.basicConfig(format=FORMAT, datefmt='%Y-%m-%d %H:%M:%S')
+LOG = logging.getLogger(__name__)
+
+
+class SecurityConfigGenerator:
+    """Security related keys and certificates configuration generator.
+
+    For when one needs to do create keys, certificates and JWT tokens.
+    """
+
+    def __init__(self, config_path, name, email):
+        """Set things up."""
+        self.name = name
+        self.email = email
+        self._config_path = config_path
+
+    def generate_token(self, password):
+        """Generate RSA Key pair to be used to sign token and the JWT Token itself."""
+        private_key = rsa.generate_private_key(public_exponent=65537, key_size=4096, backend=default_backend())
+        public_key = private_key.public_key().public_bytes(encoding=serialization.Encoding.PEM, format=serialization.PublicFormat.SubjectPublicKeyInfo)
+        pem = private_key.private_bytes(encoding=serialization.Encoding.PEM,
+                                        format=serialization.PrivateFormat.TraditionalOpenSSL,
+                                        encryption_algorithm=serialization.BestAvailableEncryption(password.encode('utf-8')))  # yeah not really that secret
+
+        privkey = serialization.load_pem_private_key(pem, password=password.encode('utf-8'), backend=default_backend())
+
+        return (pem, privkey, public_key)
+
+    def generate_user_auth(self, password):
+        """Generate user auth for CEGA Users."""
+        key = rsa.generate_private_key(backend=default_backend(), public_exponent=65537, key_size=4096)
+
+        # get public key in OpenSSH format
+        public_key = key.public_key().public_bytes(serialization.Encoding.OpenSSH, serialization.PublicFormat.OpenSSH)
+
+        # get private key in PEM container format
+        pem = key.private_bytes(encoding=serialization.Encoding.PEM, format=serialization.PrivateFormat.TraditionalOpenSSL,
+                                encryption_algorithm=serialization.BestAvailableEncryption(password.encode('utf-8')))  # yeah not really that secret
+
+        return (pem, public_key)
+
+    # Based on
+    # https://www.pythonsheets.com/notes/python-crypto.html#aes-cbc-mode-encrypt-via-password-using-cryptography
+    # Provided under MIT license: https://github.com/crazyguitar/pysheeet/blob/master/LICENSE
+
+    def _EVP_ByteToKey(self, pwd, md, salt, key_len, iv_len):
+        """Derive key and IV.
+
+        Based on https://www.openssl.org/docs/man1.0.2/crypto/EVP_BytesToKey.html
+        """
+        buf = md(pwd + salt).digest()
+        d = buf
+        while len(buf) < (iv_len + key_len):
+            d = md(d + pwd + salt).digest()
+            buf += d
+        return buf[:key_len], buf[key_len:key_len + iv_len]
+
+    def aes_encrypt(self, pwd, ptext, md):
+        """Encrypt AES."""
+        key_len, iv_len = 32, 16
+
+        # generate salt
+        salt = os.urandom(8)
+
+        # generate key, iv from password
+        key, iv = self._EVP_ByteToKey(pwd, md, salt, key_len, iv_len)
+
+        # pad plaintext
+        pad = padding.PKCS7(128).padder()
+        ptext = pad.update(ptext) + pad.finalize()
+
+        # create an encryptor
+        cipher = Cipher(algorithms.AES(key), modes.CBC(iv), backend=default_backend())
+        encryptor = cipher.encryptor()
+
+        # encrypt plain text
+        ctext = encryptor.update(ptext) + encryptor.finalize()
+        ctext = b'Salted__' + salt + ctext
+
+        # encode base64
+        return ctext
+
+    def _generate_secret(self, value):
+        """Generate secret of specifig value.
+
+        .. note: If the value is of type integer it will generate a random of that value,
+        else it will take that value.
+        """
+        if isinstance(value, int):
+            secret = ''.join(secrets.choice(string.ascii_letters + string.digits) for i in range(value))
+            return secret
+        else:
+            return value
+
+    def generate_pgp_pair(self, comment, passphrase, armor=True, active=False):
+        """Generate PGP key pair to be used by keyserver."""
+        # We need to specify all of our preferences because PGPy doesn't have any built-in key preference defaults at this time.
+        # This example is similar to GnuPG 2.1.x defaults, with no expiration or preferred keyserver
+        comment = comment if comment else "Generated for use in LocalEGA."
+        key = PGPKey.new(PubKeyAlgorithm.RSAEncryptOrSign, 4096)
+        uid = PGPUID.new(self.name, email=self.email, comment=comment)
+        key.add_uid(uid,
+                    usage={KeyFlags.Sign, KeyFlags.EncryptCommunications, KeyFlags.EncryptStorage},
+                    hashes=[HashAlgorithm.SHA256, HashAlgorithm.SHA384, HashAlgorithm.SHA512, HashAlgorithm.SHA224],
+                    ciphers=[SymmetricKeyAlgorithm.AES256, SymmetricKeyAlgorithm.AES192, SymmetricKeyAlgorithm.AES128],
+                    compression=[CompressionAlgorithm.ZLIB, CompressionAlgorithm.BZ2, CompressionAlgorithm.ZIP, CompressionAlgorithm.Uncompressed])
+
+        # Protecting the key
+        key.protect(passphrase, SymmetricKeyAlgorithm.AES256, HashAlgorithm.SHA256)
+        pub_data = str(key.pubkey) if armor else bytes(key.pubkey)  # armored or not
+        sec_data = str(key) if armor else bytes(key)  # armored or not
+
+        return (pub_data, sec_data)
+
+    def generate_ssl_certs(self, country, country_code, location, org, email, org_unit="SysDevs", common_name="LocalEGA"):
+        """Generate SSL self signed certificate."""
+        # Following https://cryptography.io/en/latest/x509/tutorial/?highlight=certificate
+        key = rsa.generate_private_key(public_exponent=65537, key_size=2048, backend=default_backend())
+        priv_key = key.private_bytes(encoding=serialization.Encoding.PEM,
+                                     format=serialization.PrivateFormat.TraditionalOpenSSL,
+                                     encryption_algorithm=serialization.NoEncryption(),)
+
+        subject = issuer = x509.Name([x509.NameAttribute(NameOID.COUNTRY_NAME, country_code),
+                                      x509.NameAttribute(NameOID.STATE_OR_PROVINCE_NAME, country),
+                                      x509.NameAttribute(NameOID.LOCALITY_NAME, location),
+                                      x509.NameAttribute(NameOID.ORGANIZATION_NAME, org),
+                                      x509.NameAttribute(NameOID.ORGANIZATIONAL_UNIT_NAME, org_unit),
+                                      x509.NameAttribute(NameOID.COMMON_NAME, common_name),
+                                      x509.NameAttribute(NameOID.EMAIL_ADDRESS, email), ])
+
+        cert = x509.CertificateBuilder().subject_name(
+            subject).issuer_name(
+            issuer).public_key(
+            key.public_key()).serial_number(
+            x509.random_serial_number()).not_valid_before(
+            datetime.datetime.utcnow()).not_valid_after(
+            datetime.datetime.utcnow() + datetime.timedelta(days=1000)).add_extension(
+            x509.SubjectAlternativeName([x509.DNSName(u"localhost")]), critical=False,).sign(
+            key, hashes.SHA256(), default_backend())
+
+        with open(self._config_path / 'ssl.cert', "w") as ssl_cert:
+            ssl_cert.write(cert.public_bytes(serialization.Encoding.PEM).decode('utf-8'))
+
+        with open(self._config_path / 'ssl.key', "w") as ssl_key:
+            ssl_key.write(priv_key.decode('utf-8'))
+
+        # return (cert.public_bytes(serialization.Encoding.PEM).decode('utf-8'), priv_key.decode('utf-8'))

--- a/setup.py
+++ b/setup.py
@@ -6,6 +6,9 @@ setup(
     packages=find_packages(),
     py_modules=['lega_init'],
     include_package_data=True,
+    project_urls={
+        'Source': 'https://github.com/neicnordic/LocalEGA-deploy-init',
+    },
     description='LocalEGA init script generating configuration parameters such as passwords and keys.',
     author='LocalEGA Developers',
     install_requires=[
@@ -20,4 +23,17 @@ setup(
             'legainit=lega_init.deploy:main'
         ]
     },
+    platforms='any',
+    classifiers=[
+        'Development Status :: 5 - Production/Stable',
+
+        'Intended Audience :: Developers',
+        'Intended Audience :: Information Technology',
+        'Topic :: Security :: Cryptography',
+
+        'License :: OSI Approved :: Apache Software License',
+
+        'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
+    ],
 )

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='lega_init',
-    version='0.1.0',
+    version='0.2.0',
     packages=find_packages(),
     py_modules=['lega_init'],
     include_package_data=True,


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Functional change
- [x] New feature
- [x] Code cleanup
- [x] Documentation change


### Pull request long description:
Refactor the the generation of configuration separating the keys and certificate generation from actual configuration. Added support to load external configuration. Added support for generating root CA and also generating CA based on CSR.

### Changes made:
1. moved password generation, certificates and keys to `key_generation`
2. added option to load custom token payload
3. added option to load custom LocalEGA config
4. `generate_root_certs` generates a Root CA and `generate_csr` generates CSR and stores them in a `csr` folder while keys and newly generated CAs are stored in `certs`
5. not sure `generate_ssl_certs` is still needed, but kept around now it generates `ega_ssl`

### Related issues:
Fixes #20 

### Additional information:
Not yet tested, should work(TM)

### Release note:
<!-- Describe if this change needs a release note present in CHANGELOG.md. -->
<!-- Also, please make sure to add the release note on top of the file CHANGELOG.md. -->

### Documentation change:
Changed the Readme as we added options to tool

### Mentions:
@jbygdell should we add the option to load CA externally?
