### PR TITLE
Add option to use custom root CA

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ The service list and their DNS Name can be loaded using `--svc-config`:
 
 Using the deploy script:
 ```
-➜ legainit --help
+➜ legainit --help                                                                                                           
 Usage: legainit [OPTIONS]
 
   Init script generating LocalEGA configuration parameters such as passwords
@@ -72,6 +72,8 @@ Options:
                           and K8s namespace
   --cega-svc-config TEXT  JSON with CEGA service list, DNSName (Optional) and
                           K8s namespace
+  --custom-ca TEXT        Load a custom root CA. Expects the key in same
+                          directory with *.key extension.
   --help                  Show this message and exit.
 
 ```
@@ -133,6 +135,8 @@ config
 ├── trace.yml
 └── users.json
 ```
+
+Note that the `root.ca.*` files will not be generated if `--custom-ca` option is used.
 
 Parameters generated in `config/trace.yml` when also using `--cega` file:
 ```yaml

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='legainit',
-    version='0.2.5',
+    version='0.3.0',
     packages=find_packages(),
     py_modules=['legainit'],
     include_package_data=True,


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] New feature
- [x] Documentation change


### Pull request long description:
Add option to specify a custom root CA to use when signing the certificates for the services.
It requires a key be provided at the same path.

### Changes made:
1. added `--custom-ca` option to `legainit` that allows to specify option to load ca
2. changed `key_generation` to account for custom CA
3. changed deploy to sign certificates with custom root CA
4. bumped version to `0.3.0` - it is a somewhat a major change.

### Related issues:
Might be needed for interfacing with CEGA.

### Documentation change:
Updated docs with new option.
