### PR TITLE
Add new services to defaults

### DIFF
--- a/lega_init/deploy.py
+++ b/lega_init/deploy.py
@@ -158,6 +158,7 @@ def main(config_path, cega, deploy_config, jwt_payload, svc_config, cega_svc_con
                      {'name': 'inbox', 'ns': 'default'}, {'name': 'ingest', 'ns': 'default'},
                      {'name': 'finalize', 'ns': 'default'}, {'name': 'verify', 'ns': 'default'},
                      {'name': 'mq-server', 'ns': 'default'}, {'name': 'db', 'ns': 'default'},
+                     {'name': 's3inbox', 'ns': 'default'}, {'name': 'doa', 'ns': 'default'},
                      # In case we run this in testing environment
                      {'name': 'tester', 'ns': 'default'}]
     if cega_svc_config:

--- a/lega_init/shell/java_certs.sh
+++ b/lega_init/shell/java_certs.sh
@@ -19,6 +19,16 @@ CONFPATH=$HERE/config
 STORETYPE=PKCS12
 STOREPASS=changeit
 
+# list of known Java based services
+services=(
+    dataedge
+    filedatabase
+    keys
+    res
+    doa
+    htsget
+)  
+
 function usage {
     echo "Usage: $0 [options]"
     echo -e "\nOptions are:"
@@ -43,16 +53,16 @@ while [[ $# -gt 0 ]]; do
     shift
 done
 
-# remove previos alias if keystore exists
+# remove previous alias if keystore exists
 # becomes problemantic if password changed
 if [[ -f "${CONFPATH}"/certs/cacerts ]]; then
     keytool -delete -alias legaCA \
             -keystore "${CONFPATH}"/certs/cacerts \
             -storepass "${STOREPASS}" -noprompt
-fi
+fi 
 
 # create java keystore for each service
-for service in dataedge filedatabase keys res; do
+for service in "${services[@]}"; do
     if [[ "${STORETYPE}" == "JKS" ]]; then
         openssl x509 -outform der -in "${CONFPATH}"/certs/"${service}".ca.crt \
                                   -out "${CONFPATH}"/certs/"${service}".ca.der

--- a/lega_init/shell/java_certs.sh
+++ b/lega_init/shell/java_certs.sh
@@ -27,6 +27,7 @@ services=(
     res
     doa
     htsget
+    inbox
 )  
 
 function usage {

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='legainit',
-    version='0.3.6',
+    version='0.3.7',
     packages=find_packages(),
     py_modules=['legainit'],
     include_package_data=True,


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->
We are planning to support S3 based inbox as well as a new LocalEGA data out solution https://github.com/neicnordic/LocalEGA-DOA

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] New feature

### Pull request long description:
<!-- Describe your pull request in detail. -->
Added `s3inbox` and `doa` to default services that will have a certificate generated.

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
1. added `s3inbox` and `doa` to default services
2. moved known Java based services to an array in bash script for p12 certificate generation
3. bumped version

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num>" to notify Github that this PR fixes an issue. -->
Tryggve2 SDA board:` change deploy-init to work with new services s3 proxy inbox and DOA`

