### PR TITLE
Refactor Java Service Certs and keys generation with DER and generate multiple crypt4gh keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,15 @@ The parameters can be configured using the `--deploy-config` options:
             "comment": "Testing keys",
             "expire": "30/DEC/30 08:00:00",
             "id": "key.1"},
-    "root_cert": {"country": "Finland", "country_code": "FI",
+    "ega_key": {"name": "Test EGA Crypt4GH key",
+                "comment": "Test EGA key",
+                "expire": "30/DEC/30 08:00:00",
+                "id": "ega_key"},
+    "user_key": {"name": "Test user Crypt4GH key",
+                  "comment": "Test user EGA key",
+                  "expire": "30/DEC/30 08:00:00",
+                  "id": "user_key"},
+  "root_cert": {"country": "Finland", "country_code": "FI",
                 "location": "Espoo", "org": "CSC",
                 "cn": "lega",
                 "org_unit": "NeIC System Developers"},
@@ -53,6 +61,7 @@ The service list and their DNS Name can be loaded using `--svc-config`:
     {"name":"mq-server", "ns": "lega"},
     {"name":"filedatabase", "ns": "lega"},
     {"name":"db", "ns": "lega"},
+    {"name":"doa", "ns": "lega"},
     {"name":"tester", "ns": "lega"}
  ]
 ```
@@ -93,13 +102,13 @@ in order to specify a path for the configuration directory use:
 legainit --config-path <path>
 ```
 The configuration also generates Java compatible certificates for `dataedge`, `res`
-`keys` and `filedatabase` services.
+`keys`, `filedatabase`, `doa`, `inbox` and `htsget` services.
 Generated `config` directory when also using `--cega` option:
 ```
-
 config
 ├── cega.conf
 ├── cega.json
+├── cega.plugins
 ├── certs
 │   ├── cacerts
 │   ├── cega-mq.ca.crt
@@ -107,48 +116,78 @@ config
 │   ├── cega-users.ca.crt
 │   ├── cega-users.ca.key
 │   ├── dataedge.ca.crt
+│   ├── dataedge.ca.crt.der
 │   ├── dataedge.ca.key
+│   ├── dataedge.ca.key.der
 │   ├── dataedge.p12
 │   ├── db.ca.crt
 │   ├── db.ca.key
+│   ├── doa.ca.crt
+│   ├── doa.ca.crt.der
+│   ├── doa.ca.key
+│   ├── doa.ca.key.der
+│   ├── doa.p12
 │   ├── ega_ssl.cert
 │   ├── ega_ssl.key
 │   ├── filedatabase.ca.crt
+│   ├── filedatabase.ca.crt.der
 │   ├── filedatabase.ca.key
+│   ├── filedatabase.ca.key.der
 │   ├── filedatabase.p12
 │   ├── finalize.ca.crt
 │   ├── finalize.ca.key
 │   ├── htsget.ca.crt
+│   ├── htsget.ca.crt.der
 │   ├── htsget.ca.key
+│   ├── htsget.ca.key.der
+│   ├── htsget.p12
 │   ├── inbox.ca.crt
+│   ├── inbox.ca.crt.der
 │   ├── inbox.ca.key
+│   ├── inbox.ca.key.der
+│   ├── inbox.p12
 │   ├── ingest.ca.crt
 │   ├── ingest.ca.key
 │   ├── keys.ca.crt
+│   ├── keys.ca.crt.der
 │   ├── keys.ca.key
+│   ├── keys.ca.key.der
 │   ├── keys.p12
 │   ├── mq-server.ca.crt
 │   ├── mq-server.ca.key
 │   ├── res.ca.crt
+│   ├── res.ca.crt.der
 │   ├── res.ca.key
+│   ├── res.ca.key.der
 │   ├── res.p12
 │   ├── root.ca.crt
 │   ├── root.ca.key
 │   ├── s3.ca.crt
 │   ├── s3.ca.key
+│   ├── s3inbox.ca.crt
+│   ├── s3inbox.ca.key
 │   ├── tester.ca.crt
 │   ├── tester.ca.key
 │   ├── verify.ca.crt
 │   └── verify.ca.key
 ├── dummy.key
 ├── dummy.pub
+├── ega_key.c4gh.pub
+├── ega_key.c4gh.sec
 ├── key.1.pub
 ├── key.1.sec
 ├── token.key
 ├── token.pub
 ├── trace.yml
+├── user_key.c4gh.pub
+├── user_key.c4gh.sec
 └── users.json
+
 ```
+
+We generate key in two formats:
+* PGP for deprecated crypt4gh format https://github.com/neicnordic/LocalEGA-cryptor 
+* [crypt4gh@v1.0.0](https://github.com/EGA-archive/crypt4gh/tree/v1.0).
 
 Note that the `root.ca.*` files will not be generated if `--custom-ca` option is used.
 
@@ -175,6 +214,8 @@ secrets:
   s3_access_key:
   s3_secret_key:
   shared_pgp_password:
+  ega_c4gh_passphrase:
+  user_c4gh_passphrase:
   token:
 ```
 

--- a/lega_init/deploy.py
+++ b/lega_init/deploy.py
@@ -19,7 +19,7 @@ LOG = logging.getLogger(__name__)
 LOG.setLevel(logging.INFO)
 
 
-def sign_cert(sec_config, conf, services, svc_prefix, provided_ca):
+def sign_cert(sec_config, conf, services, svc_prefix, provided_ca, _java_serivces):
     """Generate certificates sign requests and certificates for services."""
     for service in services:
         if svc_prefix != '':
@@ -31,19 +31,23 @@ def sign_cert(sec_config, conf, services, svc_prefix, provided_ca):
                                     location=conf['svc_cert']['location'], org=conf['svc_cert']['org'], email=conf['email'],
                                     org_unit=conf['svc_cert']['org_unit'],
                                     common_name=service['dns'],
-                                    kube_ns=service['ns'],)
+                                    kube_ns=service['ns'],
+                                    java_services=_java_serivces)
             sec_config.sign_certificate_request_dns(service['name'], service['dns'], password='password',
                                                     custom_ca=provided_ca,
-                                                    kube_ns=service['ns'],)
+                                                    kube_ns=service['ns'],
+                                                    java_services=_java_serivces)
         else:
             sec_config.generate_csr(service['name'], country=conf['svc_cert']['country'], country_code=conf['svc_cert']['country_code'],
                                     location=conf['svc_cert']['location'], org=conf['svc_cert']['org'], email=conf['email'],
                                     org_unit=conf['svc_cert']['org_unit'],
                                     common_name=_cn,
-                                    kube_ns=service['ns'],)
+                                    kube_ns=service['ns'],
+                                    java_services=_java_serivces)
             sec_config.sign_certificate_request_dns(service['name'], _cn, password='password',
                                                     custom_ca=provided_ca,
-                                                    kube_ns=service['ns'],)
+                                                    kube_ns=service['ns'],
+                                                    java_services=_java_serivces)
 
 
 def create_config(_localega, _services, _cega_services, config_path, cega, token_payload, provided_ca, _java_serivces):
@@ -91,7 +95,7 @@ def create_config(_localega, _services, _cega_services, config_path, cega, token
                                   location=_localega['root_cert']['location'], org=_localega['root_cert']['org'], email=_localega['email'],
                                   org_unit=_localega['root_cert']['org_unit'],
                                   common_name=_localega['root_cert']['cn'],)
-    sign_cert(sec_config, _localega, _services, _localega['prefix_lega'], provided_ca)
+    sign_cert(sec_config, _localega, _services, _localega['prefix_lega'], provided_ca, _java_serivces)
     pgp_pair = sec_config.generate_pgp_pair(comment=_localega['key']['comment'],
                                             passphrase=pgp_passphrase, armor=True, active=True)
     c4gh_pair = sec_config.generate_cryp4gh_pair(passphrase=c4gh_passphrase, comment=_localega['key']['comment'])
@@ -105,7 +109,7 @@ def create_config(_localega, _services, _cega_services, config_path, cega, token
         conf.generate_cega_mq_auth(cega_mq_auth_secret, _localega['broker_username'])
         conf.generate_user_auth(_localega['inbox_user'], _localega['inbox_user'], _localega['cega_user'])
         conf._trace_secrets.update(cega_users_pass=dq(sec_config._generate_secret(32)))
-        sign_cert(sec_config, _localega, _cega_services, _localega['prefix_cega'], provided_ca)
+        sign_cert(sec_config, _localega, _cega_services, _localega['prefix_cega'], provided_ca, None)
 
     conf._trace_secrets.update(pg_in_password=dq(pg_in_password))
     conf._trace_secrets.update(pg_out_password=dq(pg_out_password))

--- a/lega_init/shell/java_certs.sh
+++ b/lega_init/shell/java_certs.sh
@@ -19,23 +19,13 @@ CONFPATH=$HERE/config
 STORETYPE=PKCS12
 STOREPASS=changeit
 
-# list of known Java based services
-services=(
-    dataedge
-    filedatabase
-    keys
-    res
-    doa
-    htsget
-    inbox
-)  
-
 function usage {
     echo "Usage: $0 [options]"
     echo -e "\nOptions are:"
     echo -e "\t--config-path <value>     \tPath for the configuration directory, [Default] is ${CONFPATH} folder"
     echo -e "\t--storetype <value>       \tType of certificate to create, JKS or PKCS12, [Default] is ${STORETYPE}"
     echo -e "\t--storepass <value>       \tThe password for the keystore, [Default] is ${STOREPASS}"
+    echo -e "\t--services <value>       \tList of java services separated by comma."
     echo -e "\t--help, -h               \tOutputs this message and exits"
     echo -e "\t-- ...                   \tAny other options appearing after the -- will be ignored"
     echo ""
@@ -48,11 +38,14 @@ while [[ $# -gt 0 ]]; do
         --config-path) CONFPATH=$2; shift;;
         --storetype) STORETYPE=${2^^}; shift;;
         --storepass) STOREPASS=$2; shift;;
+        --services) services_input="${2#*}"; shift;;
         --) shift; break;;
         *) echo "$0: error - unrecognized option $1" 1>&2; usage; exit 1;;
     esac
     shift
 done
+
+IFS=',' read -r -a services <<< "$services_input"
 
 # remove previous alias if keystore exists
 # becomes problemantic if password changed

--- a/lega_init/shell/java_certs.sh
+++ b/lega_init/shell/java_certs.sh
@@ -58,11 +58,9 @@ fi
 # create java keystore for each service
 for service in "${services[@]}"; do
     if [[ "${STORETYPE}" == "JKS" ]]; then
-        openssl x509 -outform der -in "${CONFPATH}"/certs/"${service}".ca.crt \
-                                  -out "${CONFPATH}"/certs/"${service}".ca.der
         keytool -import -alias "${service}" \
                 -keystore "${CONFPATH}/certs/${service}.jks" \
-                -file "${CONFPATH}"/certs/"${service}".ca.der \
+                -file "${CONFPATH}"/certs/"${service}".ca.crt.der \
                 -storepass "${STOREPASS}" -noprompt
     else
         openssl pkcs12 -export -out "${CONFPATH}"/certs/"${service}".p12 \

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='legainit',
-    version='0.3.8',
+    version='0.4.0',
     packages=find_packages(),
     py_modules=['legainit'],
     include_package_data=True,


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Functional change
- [x] Documentation change
### Pull request long description:
<!-- Describe your pull request in detail. -->

x509 certifiactes for the java services should be in DER format and added generation of 2 crypt4gh keys and optionally the PGP key.

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
1. added option to specify from a JSON file the java services
2. `.crt` and `.key` are also encoded in DER format
3. generate 2 crypt4GH keys one for EGA (recipient) and one for a user e.g. Scientist
  - `ega_key.c4gh.sec` and  `ega_key.c4gh.pub` for EGA with password `ega_c4gh_passphrase` in `trace.yml`
  - `user_key.c4gh.sec` and  `user_key.c4gh.pub` for user with password `user_c4gh_passphrase` in `trace.yml`
4. Updated documentation
5. bumped to `0.4.0`

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num>" to notify Github that this PR fixes an issue. -->

Fixes #36 

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->
Needs some testing one can also change the keystore using the `--java-store` and the password with `--java-store-pass`


### Documentation change:
<!-- If this PR makes changes to user functionality, then the documentation has to be updated too. -->
<!-- Please, briefly outline here what has changed in terms of the user experience (UX). -->
<!-- If UX changes have been made, a maintainer should apply the 'needs-documentation-change' label. -->

Updated missing documentation for crypt4gh update and default to JKS keystore
